### PR TITLE
Provide Easy Language pyautogui demo in dedicated folder

### DIFF
--- a/examples/easy_language_pyautogui_demo/README.md
+++ b/examples/easy_language_pyautogui_demo/README.md
@@ -1,0 +1,51 @@
+# 易语言调用 pyautogui 键盘输入示例
+
+该示例展示了如何在易语言程序中调用独立的 Python 脚本，利用
+[pyautogui](https://pyautogui.readthedocs.io/) 模拟输入账号和密码。
+
+## 目录说明
+
+- `pyautogui_login_cli.py`：纯 Python 编写的命令行脚本，可选地启动目标程序，随后在当前焦点窗口中输入账号与密码。
+- `call_from_easy_language.e`：易语言示例代码，演示如何使用 `运行等待` 调用 Python 脚本，并根据返回值提示执行结果。
+
+## 使用步骤
+
+1. **安装依赖**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **在目标电脑上放置示例文件**
+
+   将整个 `easy_language_pyautogui_demo` 文件夹拷贝到易语言工程所在目录，确保易语言可以定位到 `pyautogui_login_cli.py`。
+
+3. **修改易语言示例**
+
+   - 在 `call_from_easy_language.e` 中把 `demo_user`、`demo_pass` 改为实际账号与密码；
+   - 如果 Python 未加入系统 PATH，请把 `python` 换成具体的解释器路径（例如 `C:\\Python39\\python.exe`）。
+
+4. **运行**
+
+   - 易语言程序调用脚本时，可选地给 `--target` 参数传入登录程序的路径，例如：
+
+     ```易语言
+     命令行 ＝ “python pyautogui_login_cli.py --target="C:\\Program Files\\WeGame\\wegame.exe" --username=账号 --password=密码”
+     ```
+
+   - `pyautogui_login_cli.py` 会自动等待窗口启动并依次输入账号、密码，再按下回车键提交。
+
+## 常见问题
+
+- **如何调整等待时间？**
+
+  使用 `--launch-wait` 控制启动程序后的等待秒数，`--post-wait` 控制提交后脚本停留的时间。
+
+- **如何调整键入速度？**
+
+  通过 `--typing-interval` 参数设置字符间隔（单位秒），数值越大输入越慢，能提升模拟输入的稳定性。
+
+- **如何修改提交按键？**
+
+  默认提交按键是 `enter`，可通过 `--submit-keys=enter,enter` 等形式指定多个按键序列。
+

--- a/examples/easy_language_pyautogui_demo/call_from_easy_language.e
+++ b/examples/easy_language_pyautogui_demo/call_from_easy_language.e
@@ -1,0 +1,14 @@
+.版本 2
+.局部变量 运行结果, 整数型
+.局部变量 命令行, 文本型
+
+; 根据实际 Python 路径调整命令行，以下示例默认系统 PATH 中已有 python
+命令行 ＝ “python """ ＋ 取运行目录（） ＋ “pyautogui_login_cli.py""" ＋
+    “ --username=demo_user --password=demo_pass --launch-wait=5 --post-wait=3”
+
+运行结果 ＝ 运行等待 (命令行, , 真)
+如果 (运行结果 ＝ 0)
+    信息框 (“调用成功，已模拟键入账号和密码。”)
+否则
+    信息框 (“调用失败，错误码：” ＋ 到文本 (运行结果))
+如果结束

--- a/examples/easy_language_pyautogui_demo/pyautogui_login_cli.py
+++ b/examples/easy_language_pyautogui_demo/pyautogui_login_cli.py
@@ -1,0 +1,127 @@
+"""Standalone CLI that uses pyautogui to type a username/password sequence.
+
+This script is designed to be easily invoked from external tools such as
+Easy Language (易语言).  It can optionally launch a target executable before
+performing the keyboard automation.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+try:
+    import pyautogui
+except ImportError as exc:  # pragma: no cover - import error path depends on environment
+    raise SystemExit(
+        "pyautogui is required. Install dependencies with 'pip install -r requirements.txt'."
+    ) from exc
+
+
+def wait_for(seconds: float) -> None:
+    """Sleep for the requested amount of time while displaying feedback."""
+    if seconds <= 0:
+        return
+
+    end_time = time.perf_counter() + seconds
+    while True:
+        remaining = end_time - time.perf_counter()
+        if remaining <= 0:
+            break
+        # Provide minimal feedback so callers know the script is still running.
+        print(f"Waiting... {remaining:0.1f}s remaining", end="\r", flush=True)
+        time.sleep(min(0.5, remaining))
+    print(" " * 40, end="\r", flush=True)
+
+
+def launch_target(executable: Optional[str], launch_wait: float) -> None:
+    """Launch an optional executable before performing the keyboard automation."""
+    if not executable:
+        if launch_wait > 0:
+            wait_for(launch_wait)
+        return
+
+    exe_path = Path(executable).expanduser()
+    if not exe_path.exists():
+        raise SystemExit(f"Target executable not found: {exe_path}")
+
+    try:
+        subprocess.Popen([str(exe_path)])
+    except OSError as exc:  # pragma: no cover - depends on local OS state
+        raise SystemExit(f"Failed to launch {exe_path}: {exc}") from exc
+
+    wait_for(launch_wait)
+
+
+def perform_login(
+    username: str,
+    password: str,
+    *,
+    typing_interval: float,
+    submit_keys: tuple[str, ...],
+) -> None:
+    """Use pyautogui to type the username, move focus, and submit the credentials."""
+    pyautogui.write(username, interval=typing_interval)
+    pyautogui.press("tab")
+    pyautogui.write(password, interval=typing_interval)
+    for key in submit_keys:
+        pyautogui.press(key)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--username", required=True, help="Account username to type")
+    parser.add_argument("--password", required=True, help="Account password to type")
+    parser.add_argument(
+        "--target",
+        help="Optional executable path to launch before typing (e.g. C:/Program Files/WeGame/wegame.exe)",
+    )
+    parser.add_argument(
+        "--launch-wait",
+        type=float,
+        default=8.0,
+        help="Seconds to wait after launching the target (or before typing when no target is provided)",
+    )
+    parser.add_argument(
+        "--typing-interval",
+        type=float,
+        default=0.05,
+        help="Delay between characters to improve reliability of simulated input",
+    )
+    parser.add_argument(
+        "--post-wait",
+        type=float,
+        default=5.0,
+        help="Seconds to wait after submitting credentials before exiting",
+    )
+    parser.add_argument(
+        "--submit-keys",
+        default="enter",
+        help="Comma separated key presses to send after the password (default: enter)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+
+    submit_keys = tuple(filter(None, (key.strip() for key in args.submit_keys.split(","))))
+    if not submit_keys:
+        submit_keys = ("enter",)
+
+    launch_target(args.target, args.launch_wait)
+    perform_login(
+        args.username,
+        args.password,
+        typing_interval=max(args.typing_interval, 0.0),
+        submit_keys=submit_keys,
+    )
+    wait_for(args.post_wait)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add an `easy_language_pyautogui_demo` folder with a standalone `pyautogui_login_cli.py` script and Easy Language example
- document setup and usage steps so the Python automation can run independently when called from Easy Language
- remove the previous scattered CLI and example files in favor of the new dedicated demo directory

## Testing
- python -m compileall examples/easy_language_pyautogui_demo/pyautogui_login_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cff350168c83229ff81efb35100409