### PR TITLE
Add PyInstaller build helper for pyautogui demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build.bat
 user_config copy.yaml
 /Tesseract-OCR
 /dist
+examples/easy_language_pyautogui_demo/dist/
+examples/easy_language_pyautogui_demo/build/
+examples/easy_language_pyautogui_demo/pyautogui_login_cli.spec

--- a/examples/easy_language_pyautogui_demo/README.md
+++ b/examples/easy_language_pyautogui_demo/README.md
@@ -1,0 +1,64 @@
+# 易语言调用 pyautogui 键盘输入示例
+
+该示例展示了如何在易语言程序中调用独立的 Python 脚本或由其打包的
+EXE，利用 [pyautogui](https://pyautogui.readthedocs.io/) 模拟输入账号和密码。
+
+## 目录说明
+
+- `pyautogui_login_cli.py`：纯 Python 编写的命令行脚本，可选地启动目标程序，随后在当前焦点窗口中输入账号与密码。
+- `build_exe.py`：基于 PyInstaller 的辅助脚本，一键在 `dist/` 目录生成可执行文件。
+- `call_from_easy_language.e`：易语言示例代码，演示如何使用 `运行等待` 调用脚本或生成的 EXE，并根据返回值提示执行结果。
+
+## 使用步骤
+
+1. **安装依赖**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **可选：打包成独立 EXE**
+
+   若希望易语言直接调用 EXE，可先安装 [PyInstaller](https://pyinstaller.org/)，然后执行
+
+   ```bash
+   pip install pyinstaller
+   python build_exe.py
+   ```
+
+   生成的 `dist/pyautogui_login_cli.exe` 会放在当前目录下的 `dist/` 里。易语言可直接调用该文件，无需依赖 Python 环境。
+
+3. **在目标电脑上放置示例文件**
+
+   将整个 `easy_language_pyautogui_demo` 文件夹拷贝到易语言工程所在目录，确保易语言可以定位到 `pyautogui_login_cli.py` 或生成的 EXE。
+
+4. **修改易语言示例**
+
+   - 在 `call_from_easy_language.e` 中把 `demo_user`、`demo_pass` 改为实际账号与密码；
+   - 若直接调用 Python 版本且 Python 未加入系统 PATH，请把 `python` 换成具体的解释器路径（例如 `C:\\Python39\\python.exe`）。
+   - 若已生成 EXE，请将命令行中的 `python ...py` 换成 `dist\\pyautogui_login_cli.exe`。
+
+5. **运行**
+
+   - 易语言程序调用脚本或 EXE 时，可选地给 `--target` 参数传入登录程序的路径，例如：
+
+     ```易语言
+     命令行 ＝ “dist\\pyautogui_login_cli.exe --target="C:\\Program Files\\WeGame\\wegame.exe" --username=账号 --password=密码”
+     ```
+
+   - `pyautogui_login_cli.py`（无论以 Python 还是 EXE 形式运行）会自动等待窗口启动并依次输入账号、密码，再按下回车键提交。
+
+## 常见问题
+
+- **如何调整等待时间？**
+
+  使用 `--launch-wait` 控制启动程序后的等待秒数，`--post-wait` 控制提交后脚本停留的时间。
+
+- **如何调整键入速度？**
+
+  通过 `--typing-interval` 参数设置字符间隔（单位秒），数值越大输入越慢，能提升模拟输入的稳定性。
+
+- **如何修改提交按键？**
+
+  默认提交按键是 `enter`，可通过 `--submit-keys=enter,enter` 等形式指定多个按键序列。
+

--- a/examples/easy_language_pyautogui_demo/build_exe.py
+++ b/examples/easy_language_pyautogui_demo/build_exe.py
@@ -1,0 +1,62 @@
+"""Build a standalone pyautogui_login_cli.exe using PyInstaller."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_pyinstaller() -> None:
+    try:
+        import PyInstaller  # type: ignore # noqa: F401
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        raise SystemExit(
+            "PyInstaller 未安装。请先运行 'pip install pyinstaller' 再执行本脚本。"
+        ) from exc
+
+
+def run_pyinstaller(base_dir: Path) -> None:
+    cli_path = base_dir / "pyautogui_login_cli.py"
+    if not cli_path.exists():
+        raise SystemExit(f"未找到脚本：{cli_path}")
+
+    dist_dir = base_dir / "dist"
+    build_dir = base_dir / "build"
+    spec_path = base_dir / "pyautogui_login_cli.spec"
+
+    # 清理旧的构建产物，避免 PyInstaller 读取过期配置。
+    for path in (dist_dir, build_dir, spec_path):
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        elif path.is_file():
+            path.unlink(missing_ok=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        str(cli_path),
+        "--name",
+        "pyautogui_login_cli",
+        "--onefile",
+        "--distpath",
+        str(dist_dir),
+        "--workpath",
+        str(build_dir),
+        "--specpath",
+        str(base_dir),
+    ]
+
+    subprocess.run(command, check=True)
+
+
+def main() -> int:
+    ensure_pyinstaller()
+    run_pyinstaller(Path(__file__).resolve().parent)
+    print("已在 dist/ 目录生成 pyautogui_login_cli.exe")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/easy_language_pyautogui_demo/call_from_easy_language.e
+++ b/examples/easy_language_pyautogui_demo/call_from_easy_language.e
@@ -1,0 +1,20 @@
+.版本 2
+.局部变量 运行结果, 整数型
+.局部变量 命令行, 文本型
+.局部变量 可执行文件路径, 文本型
+
+; 如果使用 Python 版本，请将下方改为 “python”。此示例假设已运行 build_exe.py
+; 并在 dist\ 目录生成了 pyautogui_login_cli.exe。
+可执行文件路径 ＝ 取运行目录（） ＋ “dist\\pyautogui_login_cli.exe”
+
+; 如果仍需要使用 Python 脚本版本，可将命令行改写为
+; 命令行 ＝ “python """ ＋ 取运行目录（） ＋ “pyautogui_login_cli.py""" ＋ ...”
+命令行 ＝ 可执行文件路径 ＋
+    “ --username=demo_user --password=demo_pass --launch-wait=5 --post-wait=3”
+
+运行结果 ＝ 运行等待 (命令行, , 真)
+如果 (运行结果 ＝ 0)
+    信息框 (“调用成功，已模拟键入账号和密码。”)
+否则
+    信息框 (“调用失败，错误码：” ＋ 到文本 (运行结果))
+如果结束

--- a/examples/easy_language_pyautogui_demo/pyautogui_login_cli.py
+++ b/examples/easy_language_pyautogui_demo/pyautogui_login_cli.py
@@ -1,0 +1,127 @@
+"""Standalone CLI that uses pyautogui to type a username/password sequence.
+
+This script is designed to be easily invoked from external tools such as
+Easy Language (易语言).  It can optionally launch a target executable before
+performing the keyboard automation.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+try:
+    import pyautogui
+except ImportError as exc:  # pragma: no cover - import error path depends on environment
+    raise SystemExit(
+        "pyautogui is required. Install dependencies with 'pip install -r requirements.txt'."
+    ) from exc
+
+
+def wait_for(seconds: float) -> None:
+    """Sleep for the requested amount of time while displaying feedback."""
+    if seconds <= 0:
+        return
+
+    end_time = time.perf_counter() + seconds
+    while True:
+        remaining = end_time - time.perf_counter()
+        if remaining <= 0:
+            break
+        # Provide minimal feedback so callers know the script is still running.
+        print(f"Waiting... {remaining:0.1f}s remaining", end="\r", flush=True)
+        time.sleep(min(0.5, remaining))
+    print(" " * 40, end="\r", flush=True)
+
+
+def launch_target(executable: Optional[str], launch_wait: float) -> None:
+    """Launch an optional executable before performing the keyboard automation."""
+    if not executable:
+        if launch_wait > 0:
+            wait_for(launch_wait)
+        return
+
+    exe_path = Path(executable).expanduser()
+    if not exe_path.exists():
+        raise SystemExit(f"Target executable not found: {exe_path}")
+
+    try:
+        subprocess.Popen([str(exe_path)])
+    except OSError as exc:  # pragma: no cover - depends on local OS state
+        raise SystemExit(f"Failed to launch {exe_path}: {exc}") from exc
+
+    wait_for(launch_wait)
+
+
+def perform_login(
+    username: str,
+    password: str,
+    *,
+    typing_interval: float,
+    submit_keys: tuple[str, ...],
+) -> None:
+    """Use pyautogui to type the username, move focus, and submit the credentials."""
+    pyautogui.write(username, interval=typing_interval)
+    pyautogui.press("tab")
+    pyautogui.write(password, interval=typing_interval)
+    for key in submit_keys:
+        pyautogui.press(key)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--username", required=True, help="Account username to type")
+    parser.add_argument("--password", required=True, help="Account password to type")
+    parser.add_argument(
+        "--target",
+        help="Optional executable path to launch before typing (e.g. C:/Program Files/WeGame/wegame.exe)",
+    )
+    parser.add_argument(
+        "--launch-wait",
+        type=float,
+        default=8.0,
+        help="Seconds to wait after launching the target (or before typing when no target is provided)",
+    )
+    parser.add_argument(
+        "--typing-interval",
+        type=float,
+        default=0.05,
+        help="Delay between characters to improve reliability of simulated input",
+    )
+    parser.add_argument(
+        "--post-wait",
+        type=float,
+        default=5.0,
+        help="Seconds to wait after submitting credentials before exiting",
+    )
+    parser.add_argument(
+        "--submit-keys",
+        default="enter",
+        help="Comma separated key presses to send after the password (default: enter)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+
+    submit_keys = tuple(filter(None, (key.strip() for key in args.submit_keys.split(","))))
+    if not submit_keys:
+        submit_keys = ("enter",)
+
+    launch_target(args.target, args.launch_wait)
+    perform_login(
+        args.username,
+        args.password,
+        typing_interval=max(args.typing_interval, 0.0),
+        submit_keys=submit_keys,
+    )
+    wait_for(args.post_wait)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- document how to package the pyautogui login CLI into a standalone executable that Easy Language can call
- add a PyInstaller helper script and update the Easy Language sample to execute the generated EXE
- expand .gitignore to exclude PyInstaller build outputs from the demo folder

## Testing
- python -m compileall examples/easy_language_pyautogui_demo

------
https://chatgpt.com/codex/tasks/task_e_68cff350168c83229ff81efb35100409